### PR TITLE
Update triggers.src

### DIFF
--- a/src/triggers.src
+++ b/src/triggers.src
@@ -13,10 +13,10 @@ on command:
         cancel event
         
 on death of player:
-        set {esx::playerDied} to true
+        set {esx::playerDied::%victim%} to true
         wait 21 ticks
-        {esx::playerDied} is set
-        clear {esx::playerDied}
+        {esx::playerDied::%victim%} is set
+        clear {esx::playerDied::%victim%}
 
 on first join:
         execute console command "sudo %player% spawn"

--- a/src/triggers.src
+++ b/src/triggers.src
@@ -12,6 +12,12 @@ on command:
         send(player, "You are currently blocked from executing any commands")
         cancel event
         
+on death of player:
+        set {esx::playerDied} to true
+        wait 21 ticks
+        {esx::playerDied} is set
+        clear {esx::playerDied}
+
 on first join:
         execute console command "sudo %player% spawn"
 # ------------


### PR DESCRIPTION
death event adds info for supersuicide to know when to stop, if the reason wasn't from supersuicide, deletes the variable
might need to increase the wait time just to make sure it works fine if the server drops tps